### PR TITLE
Fix wormhole build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,3 +40,5 @@ parts:
       - libffi-dev
       - libssl-dev
       - libsodium-dev
+      - rust-all
+      - pkg-config


### PR DESCRIPTION
Add packages required to allow this to build successfully.

Tested this with remote-build, installed and tested the application...

```
Build status as of 2023-10-18 18:06:04.116037:
        arch=armhf      state=Successfully built
        arch=ppc64el    state=Successfully built
        arch=s390x      state=Successfully built
        arch=arm64      state=Successfully built
        arch=amd64      state=Successfully built
Snapped wormhole_0.13.0+26.g88f7548_armhf.snap
Build log available at 'wormhole_armhf.1.txt'
Snapped wormhole_0.13.0+26.g88f7548_ppc64el.snap
Build log available at 'wormhole_ppc64el.1.txt'
Snapped wormhole_0.13.0+26.g88f7548_s390x.snap
Build log available at 'wormhole_s390x.1.txt'
Snapped wormhole_0.13.0+26.g88f7548_arm64.snap
Build log available at 'wormhole_arm64.1.txt'
Snapped wormhole_0.13.0+26.g88f7548_amd64.snap
Build log available at 'wormhole_amd64.1.txt'
Build complete.

```