### PR TITLE
snapcraft.yaml: enable riscv64 builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ platforms:
   arm64:
   armhf:
   ppc64el:
+  riscv64:
   s390x:
 grade: stable
 confinement: strict


### PR DESCRIPTION
Add riscv64 to the list of build architectures.

Local builds work fine with this patch and the snap is functional.